### PR TITLE
Change colour scheme of SNR plots to be colourblind-friendly, invert shaded region for added clarity

### DIFF
--- a/ptplot/science/SNRalphabeta_onthefly.py
+++ b/ptplot/science/SNRalphabeta_onthefly.py
@@ -12,6 +12,7 @@ Contains the following function:
 
 import math
 import matplotlib
+import matplotlib.pyplot as plt
 matplotlib.use('Agg')
 import numpy as np
 import os.path
@@ -78,10 +79,7 @@ def get_SNR_alphabeta_image(vw, alpha_list=[[0.1]], BetaoverH_list=[[100]],
         svg plot of AlphaBeta
     """
 
-    red = np.array([1,0,0])
-    darkgreen = np.array([0,0.7,0])
-    color_tuple = tuple([tuple(0.5*(np.tanh((0.5-f)*10)+1)*red
-                               + f**0.5*darkgreen)  for f in (np.arange(6)*0.2)])
+    color_tuple = plt.cm.plasma_r(np.linspace(0.1,1,6))
 
     # matplotlib.rc('text', usetex=usetex)
     matplotlib.rc('font', family='serif')
@@ -135,9 +133,10 @@ def get_SNR_alphabeta_image(vw, alpha_list=[[0.1]], BetaoverH_list=[[100]],
                            extent=(log10alpha[0], log10alpha[-1],
                                    log10BetaOverH[0], log10BetaOverH[-1]))
 
-    CSturb = ax.contourf(log10alpha, log10BetaOverH, tshHn, [1, 1000], colors=('gray'), alpha=0.5,
-                          extent=(log10alpha[0], log10alpha[-1],
-                                  log10BetaOverH[0], log10BetaOverH[-1]))
+    CSturb = ax.contourf(log10alpha, log10BetaOverH, tshHn, [0.0001, 1],
+                         colors=('white'), alpha=0.2, hatches='x',
+                         extent=(log10alpha[0], log10alpha[-1],
+                                 log10BetaOverH[0], log10BetaOverH[-1]))
 
     ax.clabel(CS, inline=1, fontsize=8, fmt="%.0f", manual=locs)
     ax.clabel(CStsh, inline=1, fontsize=8, fmt="%g", manual=locs_tsh)

--- a/ptplot/science/SNRubarfrstar_onthefly.py
+++ b/ptplot/science/SNRubarfrstar_onthefly.py
@@ -12,6 +12,7 @@ Contains the following function:
 
 import math
 import matplotlib
+import matplotlib.pyplot as plt
 matplotlib.use('Agg')
 import numpy as np
 import os.path
@@ -75,11 +76,8 @@ def get_SNR_image(vw_list=[[0.5]], alpha_list=[[0.1]], BetaoverH_list=[[100]],
         svg plot of UbarfRstar
     """
 
-    red = np.array([1,0,0])
-    darkgreen = np.array([0,0.7,0])
-    color_tuple = tuple([tuple(0.5*(np.tanh((0.5-f)*10)+1)*red
-                               + f**0.5*darkgreen)  for f in (np.arange(6)*0.2)])
-    
+    color_tuple = plt.cm.plasma_r(np.linspace(0.1, 1, 6))
+
     # matplotlib.rc('text', usetex=usetex)
     matplotlib.rc('font', family='serif')
     matplotlib.rc('mathtext', fontset='dejavuserif')
@@ -127,9 +125,10 @@ def get_SNR_image(vw_list=[[0.5]], alpha_list=[[0.1]], BetaoverH_list=[[100]],
                                              log10HnRstar[0], log10HnRstar[-1]))
 
     # CSturb = ax.contourf(log10Ubarf, log10HnRstar, tshHn, [0.00001, 1], colors=('gray'), alpha=0.3,
-    CSturb = ax.contourf(log10Ubarf, log10HnRstar, tshHn, [1, 1000], colors=('gray'), alpha=0.5,
-                          extent=(log10Ubarf[0], log10Ubarf[-1],
-                                  log10HnRstar[0], log10HnRstar[-1]))
+    CSturb = ax.contourf(log10Ubarf, log10HnRstar, tshHn, [0.0001, 1],
+                         colors=('white'), alpha=0.2, hatches='x',
+                         extent=(log10Ubarf[0], log10Ubarf[-1],
+                                 log10HnRstar[0], log10HnRstar[-1]))
 
     ax.clabel(CS, inline=1, fontsize=8, fmt="%.0f", manual=locs)
     ax.clabel(CStsh, inline=1, fontsize=8, fmt="%g", manual=locs_tsh)

--- a/ptplot/templates/ptplot/single_result.html
+++ b/ptplot/templates/ptplot/single_result.html
@@ -18,8 +18,8 @@
 <li>Diagonal dashed contours are the ratio of Hubble time to fluid
   turnover time. Coloured curved contours are LISA SNR for the given
   mission profile (sensitivity curve and duration).</li>
-<li>The shaded region on the SNR contour plots shows the area in which
-  the sound wave source will last longer than a Hubble time.</li>
+<li>The hatched region on the SNR contour plots shows the area in which
+  the sound wave source will last less than a Hubble time.</li>
 </ul>
 
 <p><span style="color:
@@ -46,5 +46,5 @@
   padding: 15px; background-clip: content-box"/>
 </p>
 
-  
+
 {% endblock results %}


### PR DESCRIPTION
Changes to SNR plots:
- Colour of contour lines switched to follow a plasma colour map
- Grey shaded region flipped, changed to hatched region to avoid confusion with older plots. Corresponding text on the website updated accordingly 

Pull request ported from Bitbucket (original author, @dchooper).